### PR TITLE
add planet vienna.rb feed list

### DIFF
--- a/source/planet.ini
+++ b/source/planet.ini
@@ -1,0 +1,82 @@
+title: Planet vienna.rb
+
+###########
+# Planet vienna.rb Feed List / Configuration
+#
+#  planet gets updated once a day (at 7 o'clock)
+#  runs @ http://viennarb.herokuapp.com
+#
+#   admin/backend w/ timeline (for updates) @ http://viennarb.herokuapp.com/db
+
+# add your blog feed!
+
+
+[viennarb]
+  title = vienna.rb Blog
+  link  = http://vienna-rb.at
+  feed  = http://vienna-rb.at/atom.xml
+
+[viennarbmeetup]
+  title = vienna.rb Meetups
+  link  = http://www.meetup.com/vienna-rb
+  feed  = http://www.meetup.com/vienna-rb/events/rss/vienna.rb/
+  
+# [viennarbmeetuprsvps]
+#  title = vienna.rb Meetups RSVPs
+#  link  = http://www.meetup.com/vienna-rb
+#  feed  = http://www.meetup.com/vienna-rb/rsvps/rss/vienna.rb/ 
+
+
+##############################
+# People
+
+[floor]
+  title = Floor Drees's Blog
+  link  = http://www.1stfloorgraphics.nl/blog/
+  feed  = http://www.1stfloorgraphics.nl/blog/feed/
+
+[pxlpnk]
+  title  = Andreas Tiefenthaler's Blog
+  link   = http://lab.an-ti.eu
+  feed   = http://lab.an-ti.eu/atom.xml
+
+[nuclearsquid]
+  title  = Markus Prinz's Blog
+  link   = http://nuclearsquid.com
+  feed   = http://nuclearsquid.com/feed.xml
+
+
+#################################
+# Companies
+
+
+#################################
+# Events
+
+
+
+###################################
+# Projects
+
+[beerdb]
+  title = Open Beer & Brewery Database (beer.db)
+  link  = http://groups.google.com/group/beerdb
+  feed  = https://groups.google.com/forum/feed/beerdb/topics/atom.xml?num=15
+
+[sportdb]
+  title = Open Sports Database and Friends (sport.db, football.db, etc.)
+  link  = http://groups.google.com/group/opensport
+  feed  = https://groups.google.com/forum/feed/opensport/topics/atom.xml?num=15
+  
+[slideshow]
+  title = Web Slideshow Alternatives (S9 and Friends)
+  link  = http://groups.google.com/group/webslideshow
+  feed  = https://groups.google.com/forum/feed/webslideshow/topics/atom.xml?num=15
+
+#########################
+# Meta
+
+[pluto]
+  title = Planet Pluto News & Discussions
+  link  = http://groups.google.com/group/feedreader
+  feed  = https://groups.google.com/forum/feed/feedreader/topics/atom.xml?num=15


### PR DESCRIPTION
Hello,

  As suggested at yesterday's meetup - in case there's any interest - here's a working first  Planet vienna.rb  feed list e.g. planet.ini. That's really all that's needed. 

 The Heroku hosted Sinatra web app will fetch the planet.ini from the vienna.rb repo (*) once a day (and update itself) plus fetch all feeds and update the planet site running for now @ http://viennarb.herokuapp.com

   There's a another stacked Sinatra app for the "backend" available @ http://viennarb.herokuapp.com/db

   Anyways, if there's any interest I invite you to update the planet.ini with more blogs from people, companies, projects, as you see fit.  Any questions, comments, ideas, etc. about Planet vienna.rb more than welcome. Cheers.

(*) Will add this feature with the next app update in the next days.
